### PR TITLE
Add a continue when there is no object in the node event.

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -92,6 +92,13 @@ func (c *Client) NodeWatch(listeners []NodeListener) error {
 			continue
 		}
 
+		if event.Object == nil {
+			log.WithFields(log.Fields{
+				"type": event.Type,
+			}).Error("event with nil object, ignoring")
+      continue
+		}
+
 		node := event.Object.(*v1.Node)
 		endpoint := NewEndpoint(node.Spec.ProviderID, node.Status.Addresses)
 

--- a/test.yaml
+++ b/test.yaml
@@ -2,7 +2,8 @@
 use_external: true
 haproxy:
   # path: /tmp/haproxy.socket 
-  bin: /usr/local/opt/haproxy/bin/haproxy
+  #bin: /usr/local/opt/haproxy/bin/haproxy
+  bin: /opt/homebrew/opt/haproxy/bin/haproxy
 
   # config: /dev/null
   config: scripts/haproxy.cfg


### PR DESCRIPTION
We can't really do anything without an object, so skip them.